### PR TITLE
Implemented support for multiple @XmlNs annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
 *.iml
+/target/
+/.settings/
+/.classpath
+/.project

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jaxb2-namespace-prefix
-Jaxb2 'namespace-prefix' plugin that adds `javax.xml.bind.annotation.XmlNs` annotations to `package-info.java` file according to 
+Jaxb2 'namespace-prefix' plugin that adds `javax.xml.bind.annotation.XmlNs` annotations to `package-info.java` file according to
 specific definition in the bindings.xml file. Those annotations associate namespace prefixes with XML namespace URIs.
 
 
@@ -7,7 +7,7 @@ specific definition in the bindings.xml file. Those annotations associate namesp
 
 The following package-info.java is generated automatically with the XmlNs annotation :
 
-```
+```java
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0007/3", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, xmlns = {
     @javax.xml.bind.annotation.XmlNs(namespaceURI = "http://www.ech.ch/xmlns/eCH-0007/3", prefix = "eCH-0007")
 })
@@ -16,7 +16,7 @@ package ch.ech.ech0007.v3;
 
 And then, Jaxb2 will build Xml structure that look like this :
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <eCH-0007:municipalityRoot xmlns:eCH-0007="http://www.ech.ch/xmlns/eCH-0007/3">
     <eCH-0007:swissMunicipalityType>
@@ -27,7 +27,7 @@ And then, Jaxb2 will build Xml structure that look like this :
 
 Instead of the default prefix numbering scheme :
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <ns1:municipalityRoot xmlns:ns1="http://www.ech.ch/xmlns/eCH-0007/3">
     <ns1:swissMunicipalityType>
@@ -40,7 +40,7 @@ Instead of the default prefix numbering scheme :
 
 Example's configuration with the maven-jaxb2-plugin :
 
-```
+```xml
 <plugin>
     <groupId>org.jvnet.jaxb2.maven2</groupId>
     <artifactId>maven-jaxb2-plugin</artifactId>
@@ -71,7 +71,7 @@ Example's configuration with the maven-jaxb2-plugin :
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-namespace-prefix</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.1</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -79,7 +79,7 @@ Example's configuration with the maven-jaxb2-plugin :
 
 Example of bindings.xml file :
 
-```
+```xml
 <?xml version="1.0"?>
 <jxb:bindings version="1.0"
     xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
@@ -94,6 +94,8 @@ Example of bindings.xml file :
         </jxb:schemaBindings>
         <jxb:bindings>
             <namespace:prefix name="eCH-0007" />
+            <!-- Additional @XmlNs prefix declarations to take effect for this schema/package -->
+            <namespace:prefix name="xsi" namespaceURI="http://www.w3.org/2001/XMLSchema-instance" />
         </jxb:bindings>
     </jxb:bindings>
 </jxb:bindings>
@@ -101,5 +103,6 @@ Example of bindings.xml file :
 
 # Release notes
 
+ - Version 1.2 (2016.11.30) : Implemented support for multiple @XmlNs declarations within a package, controlled by the bindings file.
  - Version 1.1 (2012.06.12) : Implemented support for multiple schemas (with different namespaces) that bind to the same java package.
  - Version 1.0 (2012.06.01) : First version.

--- a/src/main/java/org/jvnet/jaxb2_commons/plugin/namespace_prefix/NamespacePrefixPlugin.java
+++ b/src/main/java/org/jvnet/jaxb2_commons/plugin/namespace_prefix/NamespacePrefixPlugin.java
@@ -196,7 +196,13 @@ public class NamespacePrefixPlugin extends Plugin {
 						throw new RuntimeException("Unrecognized element [" + localName + "]");
 					}
 
-					final String namespaceURI = customization.element.getAttribute("namespaceURI");
+					final String namespaceURI;
+
+					if (customization.element.hasAttribute("namespaceURI")) {
+						namespaceURI = customization.element.getAttribute("namespaceURI");
+					} else {
+						namespaceURI = targetNS;
+					}
 
 					if (mappedNamespaceURIs.contains(namespaceURI)) {
 						throw new RuntimeException("Multiple mappings for namespaceURI [" + namespaceURI + "] detected");
@@ -212,12 +218,7 @@ public class NamespacePrefixPlugin extends Plugin {
 
 					mappedPrefixes.add(prefix);
 
-					if (namespaceURI.isEmpty()) {
-					    list.add(new Pair(targetNS, prefix));
-					} else {
-					    list.add(new Pair(namespaceURI, prefix));
-					}
-
+					list.add(new Pair(namespaceURI, prefix));
 					customization.markAsAcknowledged();
 				}
 			}

--- a/src/main/resources/prefix-namespace-schema.xsd
+++ b/src/main/resources/prefix-namespace-schema.xsd
@@ -7,7 +7,15 @@
 		   jxb:extensionBindingPrefixes="prefix" version="2.1">
 
 	<xs:complexType name="prefixType">
-		<xs:attribute name="name" type="xs:string" />
+		<xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="namespaceURI" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The namespaceURI to be mapped for the prefix. When omitted the namespaceURI will
+                    default to the namespace in use for the package.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
 	</xs:complexType>
 
 	<xs:element name="prefix" type="prefix:prefixType">
@@ -15,5 +23,4 @@
 			<xs:documentation>Prefix for the associated namespace/package.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-
 </xs:schema>


### PR DESCRIPTION
Please consider this pull request for the next release of the jaxb2-namespace-prefix plugin. I have added support for multiple occurrences of the 'namespace:prefix' element to allow for additional mappings (e.g. prefix xsi for namespace http://www.w3.org/2001/XMLSchema-instance). This is supported via a new optional attribute on the prefix element in the JAXB bindings configuration.

I also added the Eclipse settings to the .gitignore file and tagged the source code languages in the README.md file (for syntax highlighting), and added a release note for these changes, should they be included in a 1.2 release. The POM usage example in the README.md was also updated with the current release version.

Thanks!